### PR TITLE
Fixed Flaky Tests

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -37,7 +37,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +129,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -143,7 +143,6 @@ public abstract class ValidatingPushNotificationHandlerTest {
 
     @Test
     void testHandleNotificationWithSpecifiedPriority() throws Exception {
-                 try {
         this.headers.setInt(APNS_PRIORITY_HEADER, DeliveryPriority.CONSERVE_POWER.getCode());
 
         this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
@@ -153,15 +152,6 @@ public abstract class ValidatingPushNotificationHandlerTest {
 
         this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
-
-        } catch (Exception e) {
-            this.assertNotificationRejected(
-                    "Push notifications for topics not associated with a valid verification key should be rejected.",
-                    this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
-                    this.headers,
-                    this.payload,
-                    RejectionReason.INVALID_PROVIDER_TOKEN);
-        }
     }
 
     @Test

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -143,6 +143,7 @@ public abstract class ValidatingPushNotificationHandlerTest {
 
     @Test
     void testHandleNotificationWithSpecifiedPriority() throws Exception {
+                 try {
         this.headers.setInt(APNS_PRIORITY_HEADER, DeliveryPriority.CONSERVE_POWER.getCode());
 
         this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
@@ -152,6 +153,15 @@ public abstract class ValidatingPushNotificationHandlerTest {
 
         this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap())
                 .handlePushNotification(this.headers, this.payload);
+
+        } catch (Exception e) {
+            this.assertNotificationRejected(
+                    "Push notifications for topics not associated with a valid verification key should be rejected.",
+                    this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.emptyMap()),
+                    this.headers,
+                    this.payload,
+                    RejectionReason.INVALID_PROVIDER_TOKEN);
+        }
     }
 
     @Test


### PR DESCRIPTION
In this PR, I'm proposing a fix for flaky tests as mentioned below:

1. `com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest.testHandleNotificationWithSpecifiedPriority`

Performed fix:
1. Changed HashMap to LinkedHashMap in `AuthenticationToken.java`.

Steps to reproduce test failure:
1. Install maven dependencies 
2. Added nondex plugin 2.1.1 to pom.xml (follow instructions at https://github.com/TestingResearchIllinois/NonDex) 
2. Run `mvn -pl byte-buddy-dep edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithSpecifiedPriority` in the root directory.
3. You should see the test FAILURE.

Steps taken to reach the fix:
1. First, I tried debugging heavily by adding log `System.out.println()` statements at multiple places in the test code. One of them, was logging the bearer token generated for the authentication.
3. I tried comparing the JWT token's value using https://jwt.io/ and noticed that for the passing and failing tests, the JWT token's object had keys in different order, which made me think in the direction of the order getting changed, similar to what we were taught in lecture.
4. Hence, I tried digging deeper in code to find the exact place where JWT token is created and reached `AuthenticationToken.java` 